### PR TITLE
Always scroll conflicting with sponsor element

### DIFF
--- a/content.js
+++ b/content.js
@@ -14,16 +14,40 @@ function isScrolledToBottom(el) {
 var bindScrollListener = function() {
 
 	var target = document.getElementById('item-scroller');
-	
+
 	if (!target) {
         window.setTimeout(bindScrollListener, 250);
         return;
     }
-	
+
 	$('#item-scroller').bind('mousewheel DOMMouseScroll', function(event) {
 		document.getElementById('scrolldown').checked = false;
 	});
 };
+
+function hideScrollOnSponsorButton(div) {
+	var chatInputRenderer = 'yt-live-chat-message-input-renderer';
+
+	var observer = new MutationObserver(function(mutations) {
+		mutations.forEach((m) => {
+			$(m.target).attr('creator-open') ? $(div).hide() : $(div).show();
+		});
+	});
+	var observerOpts = {
+		childList: false,
+		attributes: true,
+		characterData: false,
+		subtree: false,
+		attributeFilter: ["creator-open"]
+	}
+
+	var sponsorClick = setInterval(() => {
+		if($(chatInputRenderer).length) {
+			observer.observe($(chatInputRenderer)[0], observerOpts);
+			clearInterval(sponsorClick);
+		}
+	}, 250);
+}
 
 $(document).ready(function() {
 
@@ -43,7 +67,8 @@ $(document).ready(function() {
                 $('#item-scroller').scrollTop(999999999);
             }
         }, 100);
-        
+
+				hideScrollOnSponsorButton(div);
         bindScrollListener();
     }
 });


### PR DESCRIPTION
When the sponsor button in the chat input area is clicked, the always scroll down option is overlain making it look messy.

![2017-05-06_17-11-19](https://cloud.githubusercontent.com/assets/16233822/25770677/48a41928-327f-11e7-8f2f-aa05d63aa570.png)

Fixed by adding an observer to toggle when it is shown. Adding just an event listener to the button sort of worked but the event wasn't bubbling up for some reason so if you set the listener to the parent or the icon wrap and click the icon you don't get an event. Didn't want heaps of listeners for the parent and children elements since that feels a bit _too_ hacky and prone to problems. So this solution works by hiding and showing the always scroll toggle when the attribute `creator-open` changes on the `yt-live-chat-message-input-renderer` wrapper element, this attribute corresponding to the sponsor popup shown in the picture above.

