### PR TITLE
Fixed "Always scroll down" checkbox

### DIFF
--- a/content.js
+++ b/content.js
@@ -121,12 +121,6 @@ var waitTillEmotesLoaded = function() {
     replaceExistingEmotes();
 };
 
-var checkIfAtBottom = function () {
-	if (document.getElementById('show-more').style.visibility == 'hidden') {
-		document.getElementById('scrolldown').checked = true;
-	}
-}
-
 var bindScrollListener = function () {
 
     var target = document.getElementById('item-scroller');
@@ -137,16 +131,11 @@ var bindScrollListener = function () {
     }
 
     $('#item-scroller').bind('mousewheel DOMMouseScroll', function (event) {
-		
-		document.getElementById('scrolldown').checked = false;
-		
-		if( event.originalEvent.detail > 0 || event.originalEvent.wheelDelta < 0 ) {
-			// Scroll Down
-			if(document.getElementById('show-more').style.visibility == 'hidden') {
-			   document.getElementById('scrolldown').checked = true;
-			}
-			window.setTimeout(checkIfAtBottom, 500);
-		}
+        if ($(this).scrollTop() + $(this).innerHeight() >= $(this)[0].scrollHeight) {
+            document.getElementById('scrolldown').checked = true;
+        } else {
+            document.getElementById('scrolldown').checked = false;
+        }
     });
 };
 


### PR DESCRIPTION
"Always scroll down" checkbox would not switch to true whenever user scrolled back down to bottom of chat. This fixes that.

Replaces code in previous resolution with a much cleaner, simpler fix.

Fix in bindScrollListener function.