### PR TITLE
Temporary fix, Emote hint on top instead of bottom

### DIFF
--- a/content.js
+++ b/content.js
@@ -460,7 +460,7 @@ var emoteCheck = function (node) {
 
             var span = document.createElement('span');
             span.setAttribute('aria-label', word);
-            span.classList.add('hint--bottom');
+            span.classList.add('hint--top');
 
             var img = document.createElement('img');
             img.src = emotes[word]['url'];


### PR DESCRIPTION
Fixes the hint going below the chatbox, having it on top pretty much fixes it because you can always just scroll up to see the rest.